### PR TITLE
Disable local accounts when using Guisso

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/reports/
 .sass-cache
 config/guisso.yml
 config/telemetry.yml
+config/guisso.yml

--- a/config/guisso.yml
+++ b/config/guisso.yml
@@ -1,4 +1,0 @@
-enabled: true
-url: http://login-stg.instedd.org
-client_id: ctLo8Poz3rRtx1x9f9lERg
-client_secret: d2JzcSiz_5obvPh1ySmH_ZQUZEDLZGa_4nX9bb7CGmk

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ RememberMe::Application.routes.draw do
 
   scope "(:locale)", :locale => /#{Locales.available.keys.join('|')}/ do
 
-    devise_for :users, :controllers => {:registrations => 'users/registrations', omniauth_callbacks: "omniauth_callbacks" } do
+    devise_for :users, :skip => [ ( :registrations if Guisso.enabled? ) ], :controllers => {:registrations => 'users/registrations', omniauth_callbacks: "omniauth_callbacks" } do
       get 'users/registrations/success', :to => 'users/registrations#success'
     end
 


### PR DESCRIPTION
If we delegate authentication to Guisso, then stop using Devise's local accounts.

We want to have this in production, since Guisso has CAPTCHA implemented to avoid automated account creation - and we want to avoid implementing CAPTCHA on each of our apps.